### PR TITLE
E2E tests failing in detox

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ export default class RNPickerSelect extends PureComponent {
                         <Picker
                             onValueChange={this.onValueChange}
                             selectedValue={this.state.selectedItem.value}
-                            testId="RNPickerSelectIOS"
+                            testID="RNPickerSelectIOS"
                         >
                             {this.renderPickerItems()}
                         </Picker>
@@ -285,7 +285,7 @@ export default class RNPickerSelect extends PureComponent {
                     style={{ position: 'absolute', top: 0, width: 1000, height: 1000 }}
                     onValueChange={this.onValueChange}
                     selectedValue={this.state.selectedItem.value}
-                    testId="RNPickerSelectAndroid"
+                    testID="RNPickerSelectAndroid"
                     mode={this.props.mode}
                     enabled={!this.props.disabled}
                 >
@@ -306,7 +306,7 @@ export default class RNPickerSelect extends PureComponent {
                     style={[this.props.style.inputAndroid, this.renderPlaceholderStyle()]}
                     onValueChange={this.onValueChange}
                     selectedValue={this.state.selectedItem.value}
-                    testId="RNPickerSelectAndroid"
+                    testID="RNPickerSelectAndroid"
                     mode={this.props.mode}
                     enabled={!this.props.disabled}
                 >

--- a/test/test.js
+++ b/test/test.js
@@ -74,11 +74,11 @@ describe('RNPickerSelect', () => {
         );
 
         wrapper
-            .find('[testId="RNPickerSelectIOS"]')
+            .find('[testID="RNPickerSelectIOS"]')
             .props()
             .onValueChange('orange', 2);
         wrapper
-            .find('[testId="RNPickerSelectIOS"]')
+            .find('[testID="RNPickerSelectIOS"]')
             .props()
             .onValueChange('yellow', 3);
         expect(wrapper.state().selectedItem.value).toEqual('yellow');
@@ -95,7 +95,7 @@ describe('RNPickerSelect', () => {
         );
 
         wrapper
-            .find('[testId="RNPickerSelectIOS"]')
+            .find('[testID="RNPickerSelectIOS"]')
             .props()
             .onValueChange('orange', 2);
         expect(onValueChangeSpy).toHaveBeenCalledWith('orange', 2);
@@ -188,7 +188,7 @@ describe('RNPickerSelect', () => {
         );
 
         wrapper
-            .find('[testId="RNPickerSelectIOS"]')
+            .find('[testID="RNPickerSelectIOS"]')
             .props()
             .onValueChange('orange', 2);
         expect(wrapper.state().selectedItem.value).toEqual('orange');
@@ -207,7 +207,7 @@ describe('RNPickerSelect', () => {
         );
 
         wrapper
-            .find('[testId="RNPickerSelectAndroid"]')
+            .find('[testID="RNPickerSelectAndroid"]')
             .props()
             .onValueChange('orange', 2);
         expect(wrapper.state().selectedItem.value).toEqual('orange');


### PR DESCRIPTION
Hi, I'm doing some e2e text with Detox and I need to select this component to emulate some user behaviors. However, the `testId` is not written right since is `testID`. 

This PR fix the issue.