### PR TITLE
Add onDonePress Prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 coverage/
 .vscode/
+.npm/

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare module 'react-native-picker-select' {
         onUpArrow?: () => void;
         onDownArrow?: () => void;
         mode?: ModeOptions;
+        onDonePress?: () => void;
     }
     class Picker extends React.Component<PickerProps> {}
     export default Picker;

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ export default class RNPickerSelect extends PureComponent {
         onUpArrow: PropTypes.func,
         onDownArrow: PropTypes.func,
         doneText: PropTypes.string,
+        onDonePress: PropTypes.func,
     };
 
     static defaultProps = {
@@ -83,6 +84,7 @@ export default class RNPickerSelect extends PureComponent {
         onUpArrow: null,
         onDownArrow: null,
         doneText: 'Done',
+        onDonePress: null,
     };
 
     static getDerivedStateFromProps(nextProps, prevState) {
@@ -239,6 +241,7 @@ export default class RNPickerSelect extends PureComponent {
                 <TouchableWithoutFeedback
                     onPress={() => {
                         this.togglePicker(true);
+                        this.props.onDonePress && this.props.onDonePress();
                     }}
                     hitSlop={{ top: 2, right: 2, bottom: 2, left: 2 }}
                 >


### PR DESCRIPTION
Allowing consumers a callback when Done is pressed.

Use case is when the Picker is used to view all values but the child is only updated when 'Done' is pressed.