### PR TITLE
Fix `textPlaceholderColor` bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,7 +190,7 @@ export default class RNPickerSelect extends PureComponent {
     getPlaceholderStyle() {
         const { placeholder, placeholderTextColor } = this.props;
 
-        if (!isEqual(placeholder, {}) && this.state.selectedItem.label === placeholder.label) {
+        if (!isEqual(placeholder, {})) {
             return {
                 color: placeholderTextColor,
             };
@@ -313,6 +313,7 @@ export default class RNPickerSelect extends PureComponent {
         return (
             <View pointerEvents="box-only" style={style.inputIOSContainer}>
                 <TextInput
+                    testID="TextInputIOS"
                     style={[
                         !hideIcon ? { paddingRight: 30 } : {},
                         style.inputIOS,

--- a/test/test.js
+++ b/test/test.js
@@ -64,6 +64,46 @@ describe('RNPickerSelect', () => {
         });
     });
 
+    describe('when placeholder is different than items', () => {
+        afterAll(() => (Platform.OS = 'ios'));
+
+        it("should set placeholderTextColor to text's color property iOS", () => {
+            const wrapper = shallow(
+                <RNPickerSelect
+                    items={selectItems}
+                    placeholder={placeholder}
+                    placeholderTextColor="red"
+                    value={null}
+                    onValueChange={() => {}}
+                />
+            );
+
+            const [_icon, _ios, placeholderStyle] = wrapper
+                .find('[testID="TextInputIOS"]')
+                .props().style;
+            expect(placeholderStyle).toEqual({ color: 'red' });
+        });
+
+        it("should set placeholderTextColor to text's color property Android", () => {
+            Platform.OS = 'android';
+
+            const wrapper = shallow(
+                <RNPickerSelect
+                    items={selectItems}
+                    placeholder={placeholder}
+                    placeholderTextColor="red"
+                    value={null}
+                    onValueChange={() => {}}
+                />
+            );
+
+            const [_icon, _android, placeholderStyle] = wrapper
+                .find('[testID="RNPickerSelectAndroid"]')
+                .props().style;
+            expect(placeholderStyle).toEqual({ color: 'red' });
+        });
+    });
+
     it('should set the selected value to state', () => {
         const wrapper = shallow(
             <RNPickerSelect


### PR DESCRIPTION
- This PR fixes the bug that wouldn't set the `textPlaceholderColor` if
the `placeholder` label was not present on the `items` and was not
currewntly selected.
- The fix simply removes this condition, since I see no reason to have
this condition for this purpose. (Any thoughts?)
- Also, implement test cases for this use case

Closes: https://github.com/lawnstarter/react-native-picker-select/issues/100