### PR TITLE
fix warning of TouchableWithoutFeedback does not work well with Text children. Wrap children in a View instead.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,9 @@ export default class RNPickerSelect extends PureComponent {
                     hitSlop={{ top: 2, right: 2, bottom: 2, left: 2 }}
                     testID="done_button"
                 >
-                    <View>
+                    <View
+                        testID="needed_for_touchable"
+                    >
                         <Text style={[defaultStyles.done, style.done]}>{doneText}</Text>
                     </View>
                 </TouchableWithoutFeedback>

--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,9 @@ export default class RNPickerSelect extends PureComponent {
                     hitSlop={{ top: 2, right: 2, bottom: 2, left: 2 }}
                     testID="done_button"
                 >
-                    <Text style={[defaultStyles.done, style.done]}>{doneText}</Text>
+                    <View>
+                        <Text style={[defaultStyles.done, style.done]}>{doneText}</Text>
+                    </View>
                 </TouchableWithoutFeedback>
             </View>
         );


### PR DESCRIPTION
Thank you for created great library of `react-native-picker-select`.
I fixed follow warning!
please check this pr.
thank you

## versions
- React Native: 0.56.0
- react-native-picker-select: 5.0.0

## problem
![image](https://user-images.githubusercontent.com/5894431/47636359-55c22200-db9b-11e8-975b-14f606cde4e1.png)

## code

```
<RNPickerSelect
    items={itemList}
    placeholder={{}}
    onValueChange={(value) => changeValue(value)}
    value={item}
>
    <Button>
           Select
     </Button>
</RNPickerSelect>
```
