### PR TITLE
fix for placeholderTextColor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ export default class RNPickerSelect extends PureComponent {
             !isEqual(this.props.placeholder, {}) &&
             this.state.selectedItem.label === this.props.placeholder.label
         ) {
-            return { color: this.props.style.placeholderColor || '#C7C7CD' };
+            return { color: this.props.placeholderTextColor || '#C7C7CD' };
         }
         return {};
     }


### PR DESCRIPTION
Was incorrectly using a style prop that doesn't exist instead of the 'placeholderTextColor' to set the placeholder text color. 