### PR TITLE
Fix error on empty items array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ export default class RNPickerSelect extends PureComponent {
             idx = 0;
         }
         return {
-            selectedItem: items[idx],
+            selectedItem: items[idx] || '',
             idx,
         };
     }


### PR DESCRIPTION
If you pass an empty array to the `items` prop, the component will throw an error. This is due to `getSelectedItem` method returning undefined for `selectedItem`.