### PR TITLE
Prevent ArrayIndexOutOfBoundsException on Android fixes #204

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -272,6 +272,8 @@ export default class RNPickerSelect extends PureComponent {
     }
 
     renderPickerItems() {
+        if (!this.state.items.map || !this.state.items.map.length) return null
+        
         return this.state.items.map((item) => {
             return (
                 <Picker.Item


### PR DESCRIPTION
When the items list is updated return null if there the list is empty to prevent Android ArrayIndexOutOfBoundsException error when a value is currently selected

fixes #204 