### PR TITLE
fix #204 no render if selectedItem is not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -457,6 +457,9 @@ export default class RNPickerSelect extends PureComponent {
     renderAndroidHeadless() {
         const { disabled, Icon, style, pickerProps } = this.props;
 
+        if (!this.state.items.find(i => i.value === this.state.selectedItem.value))
+            return null
+                               
         return (
             <View style={style.headlessAndroidContainer}>
                 {this.renderTextInputOrChildren()}
@@ -481,6 +484,9 @@ export default class RNPickerSelect extends PureComponent {
     renderAndroidNativePickerStyle() {
         const { disabled, Icon, style, pickerProps } = this.props;
 
+        if (!this.state.items.find(i => i.value === this.state.selectedItem.value))
+            return null
+        
         return (
             <View style={[defaultStyles.viewContainer, style.viewContainer]}>
                 <Picker


### PR DESCRIPTION
When using dynamically changing `items` props and there is a previously `state.selectedItem` set, if the new new `items` list coming in from props does not contain the same length and the `state.selectedItem` index in the Android native code does not exist, the `ArrayIndexOutOfBoundsException` error is thrown in the native code causing an app crash. This fix will return null if the `state.selectedItem` is not found in the newly rendered `items` list for the react-native Picker component.

fixes #204 