### PR TITLE
Fix "Done" button on iOS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -537,6 +537,7 @@ export const defaultStyles = StyleSheet.create({
         backgroundColor: '#EFF1F2',
         borderTopWidth: 0.5,
         borderTopColor: '#919498',
+        zIndex: 2,
     },
     chevronContainer: {
         flexDirection: 'row',


### PR DESCRIPTION
Restore zIndex removed in v6 release

Fixes https://github.com/lawnstarter/react-native-picker-select/issues/209