### PR TITLE
Fix issue with select not closing on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "/src"
     ],
     "dependencies": {
-        "lodash.isequal": "^4.5.0"
+        "lodash.isequal": "^4.5.0",
+        "react-native-modal": "^11.5.3"
     },
     "devDependencies": {
         "babel-jest": "^23.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import {
     ColorPropType,
     Keyboard,
-    Modal,
     Picker,
     Platform,
     Text,
@@ -11,6 +10,7 @@ import {
     TouchableWithoutFeedback,
     View,
 } from 'react-native';
+import Modal from 'react-native-modal';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash.isequal';
 import { defaultStyles } from './styles';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6352,6 +6352,21 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+react-native-animatable@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"
+  integrity sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==
+  dependencies:
+    prop-types "^15.7.2"
+
+react-native-modal@^11.5.3:
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-11.5.3.tgz#28b4c761680a165eaf1d2c0fb08e272c0191b39f"
+  integrity sha512-U6RghSkZUZ6c0LHMbwAnVscEwGoI58eXfBstVs18t50miV0GmLcJhIOu5OND+SDGVkBQFiGFRu/pTUJaA7wfGw==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-animatable "1.3.3"
+
 react-native@0.57.7:
   version "0.57.7"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.57.7.tgz#5b3af1c43366c41d8d8d2540fea8ce590060bca1"


### PR DESCRIPTION
The `<Picker>` component in iOS doesn't not play well when being embedded inside `<Modal>`. This is fixed by using the `<Modal>` component from 'react-native-modal` instead.