### PR TITLE
Test undefinedness of value in getSelectedItem

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,10 @@ export default class RNPickerSelect extends PureComponent {
             if (item.key && key) {
                 return isEqual(item.key, key);
             }
-            return isEqual(item.value, value);
+            if(item.value && value){
+                return isEqual(item.value, value);
+            }
+            return false
         });
         if (idx === -1) {
             idx = 0;


### PR DESCRIPTION
Using itemKey to select a default value, if using a placeholder without a value (which is intended), internal method getSelectedItem fails as it doesn't test the presence of an item.value before calling isEqual, and in absence of a value prop on Picker, will resolve as isEqual(undefined, undefined).

Thus, this code won't work, but should IMO:

        const items = [
          { key: 'a', label: 'a', value: 'a' },
          { key: 'b', label: 'b', value: 'b' },
          { key: 'c', label: 'c', value: 'c' },
        ]
        ... 
        <Picker
          placeholder={{
            label: "Select a value…"
          }}
          items={items}
          itemKey={"a"}
        />

A simple non-breaking change in getSelectedItem will correct this, as proposed in this pull request.

See this snack for a most comprehensive demonstration of this unexpected behavior: https://snack.expo.io/rJm7QrAEU