### PR TITLE
Extended custom Icon support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -503,6 +503,7 @@ export default class RNPickerSelect extends PureComponent {
                     >
                         {this.renderPickerItems()}
                     </Picker>
+                    {this.renderIcon()}
                 </View>
             </TouchableOpacity>
         );

--- a/test/test.js
+++ b/test/test.js
@@ -521,4 +521,22 @@ describe('RNPickerSelect', () => {
             });
         });
     });
+
+    it('renders custom icon when disabling native android picker style', () => {
+        Platform.OS = 'android';
+        const wrapper = shallow(
+            <RNPickerSelect
+                items={selectItems}
+                onValueChange={noop}
+                useNativeAndroidPickerStyle={false}
+                Icon={() => {
+                    return <View />;
+                }}
+            />
+        );
+
+        const icon = wrapper.find('[testID="icon_container"]');
+
+        expect(icon.exists()).toBeTruthy();
+    });
 });


### PR DESCRIPTION
Added for picker with disabled native android picker style.

Detected when searching for a solution in #325 