### PR TITLE
Allow for selectedItem state change for placeholder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,8 @@ export default class RNPickerSelect extends PureComponent {
 
             return {
                 ...(itemsChanged ? { items } : {}),
-                ...(selectedItemChanged ? { selectedItem } : {}),
+                selectedItem
+                // ...(selectedItemChanged ? { selectedItem } : {}),
             };
         }
 


### PR DESCRIPTION
I have not seen any issues with this, however I am probably not using all of the capabilities of this package.

I was having an issue where the placeholder would not change, even though the state for the placeholder of the parent component was changing. These changing props were not being seen because a condition a few lines above these changes were returning false when they should have been true. 

Specifically:
```
const selectedItemChanged =
            !isEqual(nextProps.value, undefined) && !isEqual(prevState.selectedItem, selectedItem); // <= kept returning false because nextProps.value always seems to be undefined

        if (itemsChanged || selectedItemChanged) {
            if (selectedItemChanged) {
                nextProps.onValueChange(selectedItem.value, idx);
            }

            return {
                ...(itemsChanged ? { items } : {}),
                selectedItem
                // ...(selectedItemChanged ? { selectedItem } : {}),
            };
        }
```

At least, I figured this was worth the review. 

Cheers