### PR TITLE
Fix wrong PickerProps import in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
 import {
     ModalProps,
-    PickerProps,
     TextInputProps,
     TextStyle,
     TouchableOpacityProps,
     ViewStyle,
 } from 'react-native';
 import React from 'react';
+import { PickerProps } from '@react-native-community/picker/typings/Picker';
 
 export interface Item {
     label: string;


### PR DESCRIPTION
The picker imported in the `src/index.js` is the one from `@react-native-community/picker`
But the one imported in the type definition file is from `react-native`. Causing a warning in the console.

Fix https://github.com/lawnstarter/react-native-picker-select/issues/350