### PR TITLE
fix: Replacing TouableOpacity with View addresses issue 354

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -473,7 +473,7 @@ export default class RNPickerSelect extends PureComponent {
         const { selectedItem } = this.state;
 
         return (
-            <TouchableOpacity
+            <View
                 testID="android_touchable_wrapper"
                 onPress={onOpen}
                 activeOpacity={1}
@@ -496,7 +496,7 @@ export default class RNPickerSelect extends PureComponent {
                         {this.renderPickerItems()}
                     </Picker>
                 </View>
-            </TouchableOpacity>
+            </View>
         );
     }
 


### PR DESCRIPTION
This PR addresses issue 354 - https://github.com/lawnstarter/react-native-picker-select/issues/354

Please advise if replacing `<TouchableOpacity/>` may have a negative affect.