### PR TITLE
Fix onValueChange called twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,8 +158,6 @@ export default class RNPickerSelect extends PureComponent {
             !isEqual(this.props.value, undefined) && !isEqual(prevState.selectedItem, selectedItem);
 
         if (itemsChanged || selectedItemChanged) {
-            this.props.onValueChange(selectedItem.value, idx);
-
             this.setState({
                 ...(itemsChanged ? { items } : {}),
                 ...(selectedItemChanged ? { selectedItem } : {}),
@@ -182,13 +180,11 @@ export default class RNPickerSelect extends PureComponent {
     onValueChange(value, index) {
         const { onValueChange } = this.props;
 
-        onValueChange(value, index);
-
         this.setState((prevState) => {
             return {
                 selectedItem: prevState.items[index],
             };
-        });
+        }, () => onValueChange(value, index));
     }
 
     onOrientationChange({ nativeEvent }) {


### PR DESCRIPTION
See https://github.com/lawnstarter/react-native-picker-select/issues/369#issuecomment-761277585
