### PR TITLE
Change @react-native-picker/picker to version 1.9.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "/src"
     ],
     "dependencies": {
-        "@react-native-picker/picker": "^1.8.3",
+        "@react-native-picker/picker": "^1.9.11",
         "lodash.isequal": "^4.5.0"
     },
     "devDependencies": {


### PR DESCRIPTION
To match expo SDK 41 version, to avoid conflicts like this:

![image](https://user-images.githubusercontent.com/823088/116296140-c446c180-a791-11eb-9c10-3ccc6965943e.png)

Thanks