### PR TITLE
Dismiss the keyboard when the picker opens on android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -499,6 +499,12 @@ export default class RNPickerSelect extends PureComponent {
                         onValueChange={this.onValueChange}
                         selectedValue={selectedItem.value}
                         {...pickerProps}
+                        onFocus={() => {
+                            Keyboard.dismiss();
+                            if (pickerProps.onFocus) {
+                                pickerProps.onFocus();
+                            }
+                        }}
                     >
                         {this.renderPickerItems()}
                     </Picker>
@@ -524,6 +530,12 @@ export default class RNPickerSelect extends PureComponent {
                     onValueChange={this.onValueChange}
                     selectedValue={selectedItem.value}
                     {...pickerProps}
+                    onFocus={() => {
+                        Keyboard.dismiss();
+                        if (pickerProps.onFocus) {
+                            pickerProps.onFocus();
+                        }
+                    }}
                 >
                     {this.renderPickerItems()}
                 </Picker>


### PR DESCRIPTION
Currently, we dismiss the soft keyboard when the picker opens, but only on iOS. This PR is trying to achieve the same behavior on Android, so both platform behavior is consistent.

Issue: https://github.com/lawnstarter/react-native-picker-select/issues/123