### PR TITLE
Move react-native-picker to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ For either platform, you can alternatively pass down a child element of your cho
 
 ### Installing
 
+This package is built around and depends on [@react-native-picker/picker](https://github.com/react-native-picker/picker). Please make sure you install it correctly (as seen below in installation steps).
+
 ```
 npm install react-native-picker-select
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "lodash.isequal": "^4.5.0"
     },
     "devDependencies": {
-        "@react-native-picker/picker": ">=2.4.0",
+        "@react-native-picker/picker": "^2.4.0",
         "@types/react-native": "^0.60.22",
         "babel-jest": "^23.6.0",
         "babel-preset-react-native": "^4.0.1",
@@ -53,7 +53,7 @@
         "react-test-renderer": "^16.6.1"
     },
     "peerDependencies": {
-        "@react-native-picker/picker": ">=2.4.0"
+        "@react-native-picker/picker": "^2.4.0"
     },
     "scripts": {
         "test": "jest",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
         "/src"
     ],
     "dependencies": {
-        "@react-native-picker/picker": "^1.8.3",
         "lodash.isequal": "^4.5.0"
     },
     "devDependencies": {
+        "@react-native-picker/picker": ">=2.4.0",
         "@types/react-native": "^0.60.22",
         "babel-jest": "^23.6.0",
         "babel-preset-react-native": "^4.0.1",
@@ -51,6 +51,9 @@
         "react-dom": "^16.6.1",
         "react-native": "0.57.7",
         "react-test-renderer": "^16.6.1"
+    },
+    "peerDependencies": {
+        "@react-native-picker/picker": ">=2.4.0"
     },
     "scripts": {
         "test": "jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,7 +999,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-picker/picker@>=2.4.0":
+"@react-native-picker/picker@^2.4.0":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.5.1.tgz#dfa13d5b97bfbedf1f7e7c608181a82f1d58b351"
   integrity sha512-/sADUfQsosMRYtrqqL3ZYZSECRygj0fXtpRLqxJfwuMEoqfvfn40756R6B1alzusVvDRZFI0ari0iQid56hA/Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,10 +999,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-picker/picker@^1.8.3":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-1.8.3.tgz#fcbf969a4add749fc37ef064a5eb55eadc93db39"
-  integrity sha512-zfr8k9L5BJVN7fIrmrto1cCptZjkGoiKWeZTsCR+XormQnWj0Tqrv0S9Ni3SvdT5JZ2OAQ9H+edMRSUvrAxwQA==
+"@react-native-picker/picker@>=2.4.0":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.5.1.tgz#dfa13d5b97bfbedf1f7e7c608181a82f1d58b351"
+  integrity sha512-/sADUfQsosMRYtrqqL3ZYZSECRygj0fXtpRLqxJfwuMEoqfvfn40756R6B1alzusVvDRZFI0ari0iQid56hA/Q==
 
 "@types/json5@^0.0.29":
   version "0.0.29"


### PR DESCRIPTION
### Problem

On a fresh install and following the readme steps, you end up with 2 versions of `@react-native-picker/picker` installed. The one that you install yourself (the readme says to) and the version that's listed in the package.json dependencies.

This leads to some bugs from the older version of `@react-native-picker/picker` bleeding into this component when used with `react-native-web`. See [this example.](https://github.com/react-native-picker/picker/issues/300)

### Solution
Move @react-native-picker/picker to peerDependencies in package.json. Keep separate install step in readme.