### PR TITLE
fix: correct types for `PickerStyle` interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import {
     ModalProps,
+    StyleProp,
     TextInputProps,
     TextStyle,
     TouchableOpacityProps,
@@ -23,30 +24,30 @@ export interface Item {
 }
 
 export interface PickerStyle {
-    chevron?: ViewStyle;
-    chevronDark?: ViewStyle;
-    chevronActive?: ViewStyle;
-    chevronContainer?: ViewStyle;
-    chevronDown?: ViewStyle;
-    chevronUp?: ViewStyle;
-    done?: TextStyle;
-    doneDark?: TextStyle;
-    doneDepressed?: TextStyle;
-    headlessAndroidContainer?: ViewStyle;
-    headlessAndroidPicker?: ViewStyle;
-    iconContainer?: ViewStyle;
-    inputAndroid?: TextStyle;
-    inputAndroidContainer?: ViewStyle;
-    inputIOS?: TextStyle;
-    inputIOSContainer?: ViewStyle;
-    inputWeb?: TextStyle;
-    modalViewBottom?: ViewStyle;
-    modalViewBottomDark?: ViewStyle;
-    modalViewMiddle?: ViewStyle;
-    modalViewMiddleDark?: ViewStyle;
-    modalViewTop?: ViewStyle;
-    placeholder?: TextStyle;
-    viewContainer?: ViewStyle;
+    chevron?: StyleProp<ViewStyle>;
+    chevronDark?: StyleProp<ViewStyle>;
+    chevronActive?: StyleProp<ViewStyle>;
+    chevronContainer?: StyleProp<ViewStyle>;
+    chevronDown?: StyleProp<ViewStyle>;
+    chevronUp?: StyleProp<ViewStyle>;
+    done?: StyleProp<TextStyle>;
+    doneDark?: StyleProp<TextStyle>;
+    doneDepressed?: StyleProp<TextStyle>;
+    headlessAndroidContainer?: StyleProp<ViewStyle>;
+    headlessAndroidPicker?: StyleProp<ViewStyle>;
+    iconContainer?: StyleProp<ViewStyle>;
+    inputAndroid?: StyleProp<TextStyle>;
+    inputAndroidContainer?: StyleProp<ViewStyle>;
+    inputIOS?: StyleProp<TextStyle>;
+    inputIOSContainer?: StyleProp<ViewStyle>;
+    inputWeb?: StyleProp<TextStyle>;
+    modalViewBottom?: StyleProp<ViewStyle>;
+    modalViewBottomDark?: StyleProp<ViewStyle>;
+    modalViewMiddle?: StyleProp<ViewStyle>;
+    modalViewMiddleDark?: StyleProp<ViewStyle>;
+    modalViewTop?: StyleProp<ViewStyle>;
+    placeholder?: StyleProp<TextStyle>;
+    viewContainer?: StyleProp<ViewStyle>;
 }
 
 type CustomModalProps = Omit<ModalProps, 'visible' | 'transparent' | 'animationType'>;


### PR DESCRIPTION
The previous typings for the `PickerStyle` interface were restrictive, preventing valid passing of arrays of styles to each of the attributes.

Updating these to use `StyleProp<XStyle>` ensures valid arrays of style objects are accepted.

Fixes: https://github.com/lawnstarter/react-native-picker-select/issues/527