### PR TITLE
fix: issue with the picker not opening on ios with the new architecture

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -415,6 +415,7 @@ export default class RNPickerSelect extends PureComponent {
         return (
             <View pointerEvents="box-only" style={containerStyle}>
                 <TextInput
+                    pointerEvents="none"
                     testID="text_input"
                     style={[
                         Platform.OS === 'ios' ? style.inputIOS : style.inputAndroid,


### PR DESCRIPTION
On the new architecture the TextInput used to display the text was intercepting events. This seems to be caused by the view-flattening algorithm moving it out of the parent view which has pointerEvents="box-only" set.

The solution would be either to add pointerEvents="none" to the TextInput itself, as done in this PR, or to disable the view flattening for the parent view (by adding collapsable={false} prop to it), so the native view structure would match the react one.
