### PR TITLE
feat: add prop dropdownItemStyle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,7 @@ export default class RNPickerSelect extends PureComponent {
     Icon: null,
     InputAccessoryView: null,
     darkTheme: false,
+    dropdownItemStyle: {},
   };
 
   static handlePlaceholder({ placeholder }) {

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ export default class RNPickerSelect extends PureComponent {
     // Custom Icon
     Icon: PropTypes.func,
     InputAccessoryView: PropTypes.func,
+    dropdownItemStyle: PropTypes.shape({}),
   };
 
   static defaultProps = {
@@ -276,10 +277,12 @@ export default class RNPickerSelect extends PureComponent {
   renderPickerItems() {
     const { items } = this.state;
     const defaultItemColor = this.isDarkTheme() ? '#fff' : undefined;
+    const { dropdownItemStyle } = this.props;
 
     return items.map((item) => {
       return (
         <Picker.Item
+          style={dropdownItemStyle}
           label={item.label}
           value={item.value}
           key={item.key || item.label}

--- a/test/test.js
+++ b/test/test.js
@@ -555,4 +555,28 @@ describe('RNPickerSelect', () => {
             });
         });
     });
+    
+    it('should apply custom styles to dropdown items', () => {
+        const customDropdownItemStyle = {
+          backgroundColor: '#d0d4da',
+          color: '#000',
+        };
+  
+        const wrapper = shallow(
+          <RNPickerSelect
+            items={selectItems}
+            placeholder={placeholder}
+            onValueChange={noop}
+            dropdownItemStyle={customDropdownItemStyle}
+          />
+        );
+  
+        wrapper.find('[testID="ios_touchable_wrapper"]').simulate('press');
+  
+        const pickerItems = wrapper.find('Picker').find('Picker.Item');
+  
+        pickerItems.forEach((item) => {
+          expect(item.props().style).toEqual(customDropdownItemStyle);
+        });
+      });
 });


### PR DESCRIPTION
# [Android Dark theme] Fixed to pass props for Background of popover

![image](https://github.com/user-attachments/assets/ca685257-9fc3-4101-9f09-c974c3e0c75a)

Dropdown item styles are changed dynamically by adding the dropdownItemStyle prop to adjust the background color, as shown in the image below.

```tsx
import React, { useState } from "react";
import { View, Text, StyleSheet, Platform } from "react-native";
import RNPickerSelect from "./RNPickerSelect";
interface Item {
label: string;
value: string;
}

const ExampleComponent: React.FC = () => {
const [selectedValue, setSelectedValue] = useState<string | null>(null);

const items: Item[] = [
	{ label: "Apple", value: "apple" },
	{ label: "Banana", value: "banana" },
	{ label: "Orange", value: "orange" },
];

const handleValueChange = (value: string) => {
	setSelectedValue(value);
	console.log("Selected Value:", value);
};

return (
	<View style={styles.container}>
		<Text>Select a Game:</Text>
		<RNPickerSelect
			onValueChange={(value) => console.log(value)}
			items={[
				{ label: "football", value: "football" },
				{ label: "Baseball", value: "baseball" },
				{ label: "Hockey", value: "hockey" },
			]}
			pickerProps={{
				mode: "dropdown",
				style: {
					backgroundColor: "green",
				},
			}}
			dropdownItemStyle={{ backgroundColor: "green", color: "white" }}
		/>
	</View>
);
};

const styles = StyleSheet.create({
container: {
flex: 1,
justifyContent: "center",
padding: 20,
},
});

export default ExampleComponent;
```
