### PR TITLE
Correct InputAccessoryView's type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ export interface PickerSelectProps {
     touchableDoneProps?: CustomTouchableDoneProps;
     touchableWrapperProps?: CustomTouchableWrapperProps;
     Icon?: React.FC;
-    InputAccessoryView?: React.ReactNode;
+    InputAccessoryView?: () => React.ReactNode;
     darkTheme?: boolean;
     dropdownItemStyle?: StyleProp<ViewStyle>,
     activeItemStyle?: StyleProp<ViewStyle>,


### PR DESCRIPTION
InputAccessoryView takes a function returning a ReactNode, not a ReactNode.