### PR TITLE
Fixed default chevron error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -519,7 +519,7 @@ export default class RNPickerSelect extends PureComponent {
           {this.renderTextInputOrChildren()}
           <Picker
             style={[
-              Icon ? { backgroundColor: 'transparent' } : {}, // to hide native icon
+              Icon ? { display: 'none' } : {}, // to hide native icon
               defaultStyles.headlessAndroidPicker,
               style.headlessAndroidPicker,
             ]}
@@ -544,7 +544,7 @@ export default class RNPickerSelect extends PureComponent {
       <View style={[defaultStyles.viewContainer, style.viewContainer]}>
         <Picker
           style={[
-            Icon ? { backgroundColor: 'transparent' } : {}, // to hide native icon
+            Icon ? { display: 'none' } : {}, // to hide native icon
             style.inputAndroid,
             this.getPlaceholderStyle(),
           ]}


### PR DESCRIPTION
As per my issue #678, the default chevron wasn't being hidden if a custom icon was being used.
The issue appeared to be setting the background color to transparent, as this didn't fully remove the icon. Changing this instead to display: 'none' fixed it.