### PR TITLE
fix: Add viewContainer styles to android headless wrapper component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -514,6 +514,11 @@ export default class RNPickerSelect extends PureComponent {
         onPress={onOpen}
         activeOpacity={1}
         {...touchableWrapperProps}
+        style={{
+          ...touchableWrapperProps.style,
+          ...defaultStyles.viewContainer,
+          ...style.viewContainer
+        }}
       >
         <View style={style.headlessAndroidContainer}>
           {this.renderTextInputOrChildren()}


### PR DESCRIPTION
viewContainer is not applied to android headless like on iOs or android native pickers.
This simply spread the viewContainer style to the wrapper component